### PR TITLE
chore(release): v1.0.2-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marcomattes/epaper-components",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@marcomattes/epaper-components",
-      "version": "1.0.1",
+      "version": "1.0.2-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marcomattes/epaper-components",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.1",
   "description": "E-Paper web component library — vanilla custom elements with design tokens. Zero runtime dependencies, framework-agnostic.",
   "license": "MIT",
   "author": "Marco Mattes",


### PR DESCRIPTION
Prerelease to exercise the staged tag pipeline end to end (`guard → checks → release → update`) without touching the `latest` dist-tag.

Because the version carries a prerelease part, `guard` resolves the channel to `next`, so `latest` stays on `1.0.1`. `CHANGELOG.md` has no `## [1.0.2-rc.1]` section, which also exercises the release-notes fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ub6MtYp3XvKLajgf2Hkpw