### PR TITLE
chore: reset version to 1.0.1 and document the PR-based release flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
   and `update` installs the published version from the registry, registers the
   elements in jsdom (`scripts/smoke-test.mjs`), verifies the provenance
   attestation and redeploys the site and Storybook from the tagged source.
+- `npm run bump-version` no longer creates the tag when run off `main`, since
+  `main` requires a pull request and a squash or rebase merge would strand a
+  tag created on the branch. It prints the post-merge tagging steps instead.
 
 ## [1.0.1] — 2026-08-12
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,16 +142,27 @@ npm i @marcomattes/epaper-components@dev
 ```
 
 The version is stamped inside the job and never committed, so `main` always
-carries the last released version in `package.json`.
+carries the last stable version in `package.json`.
 
-**`latest` channel.** Cut a release in three steps:
+**`latest` channel.** `main` is protected by a ruleset that requires a pull
+request, so the version bump goes through one like any other change. The tag
+is created afterwards, on the merged commit:
 
 1. Move the `[Unreleased]` entries in `CHANGELOG.md` into a
    `## [x.y.z] — YYYY-MM-DD` section. Those lines become the GitHub Release
-   notes verbatim.
-2. `npm run bump-version -- patch|minor|major` — bumps `package.json`, builds,
-   commits and creates the annotated `vx.y.z` tag.
-3. `git push --follow-tags`.
+   notes verbatim; without a matching section the notes fall back to a link.
+2. On a release branch, run `npm run bump-version -- patch|minor|major`. It
+   bumps `package.json`, builds, and commits. Off `main` it deliberately does
+   not tag, and prints the remaining steps.
+3. Open the pull request and merge it **with a merge commit**. A squash or
+   rebase merge rewrites the bump commit, which would leave the tag pointing
+   at an object that never reaches `main`.
+4. `git checkout main && git pull`, then tag the merged commit and push it:
+
+   ```sh
+   git tag -a vx.y.z -m "Release vx.y.z"
+   git push origin vx.y.z
+   ```
 
 The tag run is staged: it first refuses any tag whose name is not
 `v<package.json version>`, then re-runs the full quality gate by calling

--- a/README.md
+++ b/README.md
@@ -686,6 +686,9 @@ Tags carrying a prerelease part, such as `v1.1.0-rc.1`, are published under the
 `next` dist-tag instead of `latest`. The site is additionally redeployed on every
 push to `main` by `.github/workflows/deploy.yml`.
 
+`main` requires a pull request, so the version bump is merged before the tag is
+pushed; [CONTRIBUTING.md](./CONTRIBUTING.md) documents the exact sequence.
+
 ## License
 
 MIT. See [LICENSE](./LICENSE).

--- a/claude.md
+++ b/claude.md
@@ -159,10 +159,17 @@ CI runs all of the above on every PR (`.github/workflows/ci.yml`).
   `scripts/smoke-test.mjs`, `deploy` calls `deploy.yml` for the tagged
   source). Tags with a prerelease part (`v1.1.0-rc.1`) go to `next`.
 
+**`main` is protected** by a ruleset (`Baseline`): pull request required
+(0 approvals), no force-push, no deletion, and no bypass actors. Direct
+pushes fail — every change, including a version bump, goes through a PR.
+Tags are not covered by the ruleset and can be pushed directly.
+
 Cutting a release: move `[Unreleased]` entries into a
-`## [x.y.z] — YYYY-MM-DD` section, then
-`npm run bump-version -- patch|minor|major` (bumps, builds, commits, tags)
-and `git push --follow-tags`.
+`## [x.y.z] — YYYY-MM-DD` section, then on a release branch run
+`npm run bump-version -- patch|minor|major` (bumps, builds, commits; it
+skips tagging off `main` and prints the remaining steps). Merge the PR
+**with a merge commit** — squash or rebase would rewrite the bump commit
+and strand the tag — then tag the merged commit on `main` and push the tag.
 
 ## Common gotchas
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marcomattes/epaper-components",
-  "version": "1.0.2-rc.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@marcomattes/epaper-components",
-      "version": "1.0.2-rc.1",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marcomattes/epaper-components",
-  "version": "1.0.2-rc.1",
+  "version": "1.0.1",
   "description": "E-Paper web component library — vanilla custom elements with design tokens. Zero runtime dependencies, framework-agnostic.",
   "license": "MIT",
   "author": "Marco Mattes",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -24,6 +24,10 @@ function run(command) {
   execSync(command, { stdio: 'inherit' });
 }
 
+function capture(command) {
+  return execSync(command, { encoding: 'utf8' }).trim();
+}
+
 run(`npm version ${input} --no-git-tag-version`);
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
@@ -33,6 +37,27 @@ const commitMessage = `chore(release): bump version to v${version}`;
 run('npm run build');
 run('git add --all');
 run(`git commit -m "${commitMessage}"`);
-run(`git tag -a v${version} -m "Release v${version}"`);
 
-console.log(`✅ Released version v${version} and created git tag v${version}`);
+// `main` is protected by a ruleset that requires a pull request, so the bump
+// lands through a PR. Tagging here would be wrong: a squash or rebase merge
+// rewrites this commit, and the tag would point at an object that never
+// reaches `main`. On a release branch the tag is therefore left to the
+// maintainer, after the merge.
+const branch = capture('git rev-parse --abbrev-ref HEAD');
+const defaultBranch = 'main';
+
+if (branch === defaultBranch) {
+  run(`git tag -a v${version} -m "Release v${version}"`);
+  console.log(`\n✅ Bumped to v${version}, committed and tagged.`);
+  console.log('   Push with: git push --follow-tags');
+} else {
+  console.log(`\n✅ Bumped to v${version} and committed on ${branch} (not tagged).`);
+  console.log('   Next:');
+  console.log(`     git push -u origin ${branch}`);
+  console.log(`     gh pr create --base ${defaultBranch} --title "${commitMessage}"`);
+  console.log('     gh pr merge <n> --merge      # a merge commit keeps this commit reachable');
+  console.log(`     git checkout ${defaultBranch} && git pull`);
+  console.log(
+    `     git tag -a v${version} -m "Release v${version}" && git push origin v${version}`,
+  );
+}


### PR DESCRIPTION
Follow-up to the `v1.0.2-rc.1` pipeline test.

- `package.json` back to `1.0.1`. The RC was a test artifact, not a release candidate for a feature, so `main` should carry the last stable version again — which is also what the dev channel computes its next patch from.
- `scripts/bump-version.mjs` no longer tags when it runs off `main`. Under the new ruleset the bump lands via PR, and a squash or rebase merge would rewrite the commit the tag points at. It now prints the post-merge steps instead.
- `CONTRIBUTING.md`, `CLAUDE.md` and the README document the sequence that actually works: release branch → PR → **merge commit** → tag on `main` → push tag.

Still open, needs npm 2FA and cannot be done from CI:

```sh
npm dist-tag rm @marcomattes/epaper-components next
npm deprecate @marcomattes/epaper-components@1.0.2-rc.1 "Pipeline test release — not intended for use."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ub6MtYp3XvKLajgf2Hkpw