### PR TITLE
ci: drop the master branch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
+    branches: [main]
   # Called as the checks stage of release.yml, so the release gate and the PR
   # gate are the same definition rather than two copies that drift apart.
   workflow_call: {}


### PR DESCRIPTION
`master` was a leftover from a previous life of the repository — its last commit was dated 2020-06-15 and it shared no history with the current project. It has been deleted, so the trigger could never fire again.

Deleted branch tips, for the record (GitHub can also restore them from the respective PR pages for a while):

| Branch | Tip | Last commit |
|---|---|---|
| `codex/add-horizontal-and-vertical-steppers,-snackbar,-skeleton` | `88a546e3be0b` | 2026-02-06 (PR #17, closed unmerged) |
| `codex/add-links-and-showcase-elements-to-storybook` | `f7f0aad8011e` | 2026-02-07 (PR #18, merged) |
| `master` | `4e1a742f0ba7` | 2020-06-15 |
| `try3` | `e4116a03285d` | 2026-02-07 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ub6MtYp3XvKLajgf2Hkpw